### PR TITLE
[희정] 쪽지함, 쿠폰관리, 입사지원제한자

### DIFF
--- a/src/main/java/com/it/workit/admin/message/controller/adminMessageController.java
+++ b/src/main/java/com/it/workit/admin/message/controller/adminMessageController.java
@@ -14,6 +14,8 @@ import com.it.workit.getmessage.model.GetMessageService;
 import com.it.workit.getmessage.model.GetMessageVO;
 import com.it.workit.message.model.MessageService;
 import com.it.workit.message.model.MessageVO;
+import com.it.workit.users.model.UsersService;
+import com.it.workit.users.model.UsersVO;
 
 @Controller
 @RequestMapping("/admin")
@@ -22,6 +24,7 @@ public class adminMessageController {
 	
 	@Autowired private MessageService messageService;
 	@Autowired private GetMessageService getMessageService;
+	@Autowired private UsersService userService;
 	
 	@RequestMapping("/message/sendMessage.do")
 	public void sendMsgView(@RequestParam String corpName, @RequestParam int userNo, Model model) {
@@ -32,19 +35,11 @@ public class adminMessageController {
 	
 	@ResponseBody
 	@RequestMapping("/message/sendMessageAjax.do")
-	public int sendMsg(@ModelAttribute MessageVO vo, @RequestParam int getMessageNo) {
+	public int sendMsg(@ModelAttribute MessageVO vo, @RequestParam int getUserNo) {
 		vo.setUserNo(999);
-		int cnt = messageService.insertMessage(vo);
-		logger.info("MessageVO={}, getMessageNo={}", vo, getMessageNo);
 		
-		if(cnt>0) {
-			GetMessageVO gVo =  new GetMessageVO();
-			
-			gVo.setUserNo(getMessageNo);
-			gVo.setMessageNo(vo.getMessageNo());
-			logger.info("GetMessageVO={}", gVo);
-			cnt = getMessageService.insertGetMessage(gVo);
-		}
+		int cnt = messageService.insertMessage(vo, getUserNo);
+		logger.info("MessageVO={}, getUserNo={}", vo, getUserNo);
 		
 		return cnt;
 	}

--- a/src/main/java/com/it/workit/applicant/controller/CorpApplicantController.java
+++ b/src/main/java/com/it/workit/applicant/controller/CorpApplicantController.java
@@ -63,7 +63,8 @@ public class CorpApplicantController {
 		int pass = appService.selectPassCount(searchVo);
 		int fail = appService.selectFailCount(searchVo);
 		int open = appService.selectReadCount(searchVo);
-		int prohibited = prohibitService.selectProhibitCount(searchVo);
+		int prohibited = prohibitService.selectProhibitTotal(userNo);
+		logger.info("prohibited={}", prohibited);
 		
 		model.addAttribute("applist", applist);	//5개씩 출력됨
 		model.addAttribute("pagingInfo", pagingInfo);

--- a/src/main/java/com/it/workit/applicant/model/ApplicantServiceImpl.java
+++ b/src/main/java/com/it/workit/applicant/model/ApplicantServiceImpl.java
@@ -97,7 +97,7 @@ public class ApplicantServiceImpl implements ApplicantService{
 	public int selectReadCount(CorpApplicantPagingVO vo) {
 		return applicantDao.selectReadCount(vo);
 	}
-
+	
 	@Override
 	public int insertApplican(ApplicantlistVO appliVo) {
 		return applicantDao.insertApplican(appliVo);

--- a/src/main/java/com/it/workit/coupon/controller/AdminCouponController.java
+++ b/src/main/java/com/it/workit/coupon/controller/AdminCouponController.java
@@ -10,6 +10,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import com.it.workit.coupon.model.CouponService;
 import com.it.workit.coupon.model.CouponVO;
@@ -58,7 +59,7 @@ public class AdminCouponController {
 		
 		return "common/message";
 	}
-
+	
 	@RequestMapping("/updateForm.do")
 	public void updateForm(@RequestParam (defaultValue = "0") int couponNo, Model model) {
 		logger.info("쿠폰 수정하기");
@@ -77,8 +78,9 @@ public class AdminCouponController {
 		model.addAttribute("couponEnddate", couponEnddate);
 	}
 	
+	@ResponseBody
 	@RequestMapping("/update.do")
-	public String update(@ModelAttribute CouponVO vo, @RequestParam String start, @RequestParam String end, Model model) {
+	public int update(@ModelAttribute CouponVO vo, @RequestParam String start, @RequestParam String end) {
 		logger.info("쿠폰 수정처리 CouponVO={}", vo);
 		logger.info("start={} end={}", start, end);
 		
@@ -94,25 +96,7 @@ public class AdminCouponController {
 		vo.setCouponEnddate(couponEnddate);
 		
 		int cnt = couponService.updateCoupon(vo);
-		
-		String msg = "쿠폰수정에 실패하였습니다.", url="/admin/paidService/coupon/updateForm.do?couponNo="+vo.getCouponNo();
-		if(cnt>0) {
-			msg="쿠폰을 성공적으로 수정하였습니다";
-		}
-		
-		model.addAttribute("msg", msg);
-		model.addAttribute("url", url);
-		
-		return "common/message";
+		return cnt;
 	}
-	
-	/*
-	@ResponseBody
-	@RequestMapping("/showInfo.do")
-	public CouponVO showInfo(@RequestParam (defaultValue = "0") int couponNo) {
-		CouponVO vo= couponService.selectCouponByNo(couponNo);
-		return vo;
-	}
-	*/
 	
 }

--- a/src/main/java/com/it/workit/getmessage/model/GetMessageDAO.java
+++ b/src/main/java/com/it/workit/getmessage/model/GetMessageDAO.java
@@ -10,9 +10,12 @@ public interface GetMessageDAO {
 	//읽음 처리
 	int updateReadCount(int messageNo);
 	
+	//중요쪽지함 조회
+	List<Map<String, Object>> selectImpMessage(int userNo);
+	
 	//중요플래그 업데이트 => 받은메세지 중 보관하고 싶은 쪽지
 	int updategetMsgImpflag(int messageNo);
 	
-	//중요쪽지함 조회
-	List<Map<String, Object>> selectImpMessage(int userNo);
+	//삭제플래그 업데이트 => 받은 메세지 삭제
+	int updategetMsgDelflag(int getMessageNo);
 }

--- a/src/main/java/com/it/workit/getmessage/model/GetMessageDAOMybatis.java
+++ b/src/main/java/com/it/workit/getmessage/model/GetMessageDAOMybatis.java
@@ -33,4 +33,10 @@ public class GetMessageDAOMybatis implements GetMessageDAO{
 	public List<Map<String, Object>> selectImpMessage(int userNo) {
 		return sqlSession.selectList(namespace+"selectImpMessage", userNo);
 	}
+	
+	//받은 메세지 삭제 (플래그 업데이트)
+	@Override
+	public int updategetMsgDelflag(int getMessageNo) {
+		return sqlSession.update(namespace+"updategetMsgDelflag", getMessageNo);
+	}
 }

--- a/src/main/java/com/it/workit/getmessage/model/GetMessageService.java
+++ b/src/main/java/com/it/workit/getmessage/model/GetMessageService.java
@@ -3,6 +3,8 @@ package com.it.workit.getmessage.model;
 import java.util.List;
 import java.util.Map;
 
+import com.it.workit.message.model.MessageVO;
+
 public interface GetMessageService {
 	int insertGetMessage(GetMessageVO gVo);
 	int updateReadCount(int messageNo);
@@ -14,4 +16,8 @@ public interface GetMessageService {
 	
 	//보관함 조회
 	List<Map<String, Object>> selectImpMessage(int userNo);
+	
+	//삭제플래그 업데이트 => 받은 메세지 삭제(개별/다중)
+	int updategetMsgDelflag(int getMessageNo);
+	int updategetMsgDelflag(List<GetMessageVO> getMsgList);
 }

--- a/src/main/java/com/it/workit/getmessage/model/GetMessageServiceImpl.java
+++ b/src/main/java/com/it/workit/getmessage/model/GetMessageServiceImpl.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
+import com.it.workit.message.model.MessageVO;
+
 @Service
 public class GetMessageServiceImpl implements GetMessageService{
 
@@ -54,4 +56,31 @@ public class GetMessageServiceImpl implements GetMessageService{
 	public List<Map<String, Object>> selectImpMessage(int userNo) {
 		return getMessageDao.selectImpMessage(userNo);
 	}
+	
+	//받은 메세지 삭제 (플래그 업데이트) - 개별
+	@Override
+	public int updategetMsgDelflag(int getMessageNo) {
+		return getMessageDao.updategetMsgDelflag(getMessageNo);
+	}
+	
+	//받은 메세지 삭제 (플래그 업데이트) - 다중
+	@Override
+	@Transactional
+	public int updategetMsgDelflag(List<GetMessageVO> getMsgList) {
+		int cnt=0;
+		try {
+			for(GetMessageVO vo : getMsgList) {
+				int messageNo = vo.getMessageNo();
+				if(messageNo!=0) {	//체크된것만 
+					cnt=getMessageDao.updategetMsgDelflag(messageNo);	//삭제
+				}
+			}//commit
+		} catch (RuntimeException e) {	
+			e.printStackTrace();
+			cnt=-1;	
+			TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
+		}
+		return cnt;
+	}
+
 }

--- a/src/main/java/com/it/workit/message/controller/MessageController.java
+++ b/src/main/java/com/it/workit/message/controller/MessageController.java
@@ -93,45 +93,40 @@ public class MessageController {
 		logger.info("쪽지 쓰기 처리, 파라미터 userId={}", userId);
 		logger.info("쪽지 답장쓰기 처리, 파라미터 getMessageNo={}", getMessageNo);
 		
-		String sentUserID="";
+		String sentUserID=""; int userNo=0;
 		if(getMessageNo!=0) {
 			Map<String, Object> map = messageService.selectByMessageNo(getMessageNo);
 			int sentUserNo = Integer.parseInt(String.valueOf(map.get("USER_NO")));
 			UsersVO uVo = userService.selectByUserNo(sentUserNo);
 			sentUserID = uVo.getUserId();
-			logger.info("보낸회원 sentUserID={}", sentUserID);
+			userNo = uVo.getUserNo();
+			logger.info("보낸회원 sentUserID={} userNo={}", sentUserID, userNo);
 		}
 
-		String myId = (String) session.getAttribute("userId");
-		logger.info("세션 로그인 아이디 조회, myId={}", myId);
-
-		int cnt = messageService.insertMessage(vo);
+		if(userId==null || userId.isEmpty()) {
+			if(sentUserID==null || sentUserID.isEmpty()) {
+				userNo = (Integer) session.getAttribute("userNo");
+			}
+		}else {
+			//일반 쪽지쓰기
+			UsersVO uVo = new UsersVO();
+			uVo = userService.selectByUserId(userId);
+			userNo = uVo.getUserNo();
+		}
+		
+		int cnt = messageService.insertMessage(vo, userNo);
+		
 		String msg="쪽지 전송 실패", url="/message/messageWrite.do";
 		if(cnt>0) {
 			if(userId==null || userId.isEmpty()) {
 				if(sentUserID!=null && !sentUserID.isEmpty()) {
-					userId=sentUserID;
-					msg = userId+"님에게 답장을 성공적으로 보냈습니다.";
-				}else {
-					userId=myId;	//유저아이디가 없는 경우 => 나에게 보내는 쪽지
+					msg = sentUserID+"님에게 답장을 성공적으로 보냈습니다.";
+				}else{
 					msg = "쪽지를 성공적으로 보냈습니다.\\n\\n나에게 쓴 쪽지는 [나에게 쓴 쪽지함]에서 확인할 수 있습니다.";
 				}
 			}else {
 				msg = userId+"님에게 쪽지를 성공적으로 보냈습니다.";
 			}
-
-			//쪽지 쓰면 getmessage에도 insert되어야 함
-			//1. userid로 userno 조회
-			UsersVO userVo = userService.selectByUserId(userId);
-
-			//2. getMessageVo 세팅
-			GetMessageVO gVo =  new GetMessageVO();
-			gVo.setUserNo(userVo.getUserNo());
-			gVo.setMessageNo(vo.getMessageNo());
-
-			//3. getMessage insert
-			int count = getMessageService.insertGetMessage(gVo);
-			logger.info("getMessage insert 결과 count={}", count);
 		}
 
 		model.addAttribute("msg", msg);

--- a/src/main/java/com/it/workit/message/controller/MessageController.java
+++ b/src/main/java/com/it/workit/message/controller/MessageController.java
@@ -205,7 +205,7 @@ public class MessageController {
 				url="/message/messageBoxSend.do";
 			}else if(getMessageNo!=0) {
 				//받은 쪽지 삭제
-				cnt = messageService.updategetMsgDelflag(getMessageNo);
+				cnt = getMessageService.updategetMsgDelflag(getMessageNo);
 
 				Map<String, Object>  map = messageService.selectByMessageNo(getMessageNo);
 				int important = Integer.parseInt(String.valueOf(map.get("GETMESSAGE_IMPFLAG")));
@@ -309,6 +309,37 @@ public class MessageController {
 
 		return "common/message";
 		
+	}
+	
+	//받은쪽지함, 내가보낸쪽지함, 쪽지보관함 다중 삭제처리
+	@RequestMapping("/deleteMultigetMsg.do")
+	public String deleteMultigetMsg(@ModelAttribute GetMessageListVO getMsgListVo,
+			@RequestParam (required = false) String type, Model model) {
+		logger.info("선택한 쪽지 삭제(플래그 갱신) 처리, 파라미터 GetMessageListVO={}", getMsgListVo);
+		
+		List<GetMessageVO> getMsgList = getMsgListVo.getGetMsgItems();
+		int cnt = getMessageService.updategetMsgDelflag(getMsgList);
+		logger.info("선택한 쪽지 삭제 결과, cnt={}", cnt);
+		
+		String msg="선택한 쪽지 삭제 실패!", url="/message/messageBox.do";
+		if(type!=null && !type.isEmpty() && type.equals("toMe")) {
+			url="/message/messageBox.do?type=toMe";
+		}else if(type!=null && !type.isEmpty() && type.equals("important")){
+			url="/message/messageBox.do?type=important";
+		}
+		
+		if(cnt>0) {
+			msg="선택한 쪽지를 삭제하였습니다.";
+			for(int i=0;i<getMsgList.size();i++) {
+				GetMessageVO getMsgVo = getMsgList.get(i);
+				logger.info("[{}] : messageNo={}", i, getMsgVo.getMessageNo());
+			}//for
+		}
+		
+		model.addAttribute("msg", msg);
+		model.addAttribute("url", url);
+		
+		return "common/message";
 	}
 	
 	@RequestMapping("/impMultiGetMsg.do")

--- a/src/main/java/com/it/workit/message/model/MessageDAO.java
+++ b/src/main/java/com/it/workit/message/model/MessageDAO.java
@@ -4,10 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import com.it.workit.getmessage.model.GetMessageVO;
+import com.it.workit.position.model.PositionsuggestVO;
 
 public interface MessageDAO {
 	//메세지 보내기
 	int insertMessage(MessageVO vo);
+	MessageVO selectMsgJustNow(int userNo);
 	
 	//받은 메세지 뷰 조회
 	List<Map<String, Object>> selectGetMessage(int userNo);

--- a/src/main/java/com/it/workit/message/model/MessageDAO.java
+++ b/src/main/java/com/it/workit/message/model/MessageDAO.java
@@ -24,6 +24,4 @@ public interface MessageDAO {
 	//삭제플래그 업데이트 => 보낸 메세지 삭제 (개별)
 	int updateMsgDelflag(int messageNo);
 	
-	//삭제플래그 업데이트 => 받은 메세지 삭제
-	int updategetMsgDelflag(int messageNo);
 }

--- a/src/main/java/com/it/workit/message/model/MessageDAOMybatis.java
+++ b/src/main/java/com/it/workit/message/model/MessageDAOMybatis.java
@@ -44,11 +44,5 @@ public class MessageDAOMybatis implements MessageDAO{
 	public int updateMsgDelflag(int messageNo) {
 		return sqlSession.update(namespace+"updateMsgDelflag", messageNo);
 	}
-	
-	//받은 메세지 삭제 (플래그 업데이트)
-	@Override
-	public int updategetMsgDelflag(int messageNo) {
-		return sqlSession.update(namespace+"updategetMsgDelflag", messageNo);
-	}
 
 }

--- a/src/main/java/com/it/workit/message/model/MessageDAOMybatis.java
+++ b/src/main/java/com/it/workit/message/model/MessageDAOMybatis.java
@@ -20,6 +20,11 @@ public class MessageDAOMybatis implements MessageDAO{
 	}
 
 	@Override
+	public MessageVO selectMsgJustNow(int userNo) {
+		return sqlSession.selectOne(namespace+"selectMsgJustNow", userNo);
+	}
+	
+	@Override
 	public List<Map<String, Object>> selectSentMessage(int userNo) {
 		return sqlSession.selectList(namespace+"selectSentMessage", userNo);
 	}

--- a/src/main/java/com/it/workit/message/model/MessageService.java
+++ b/src/main/java/com/it/workit/message/model/MessageService.java
@@ -4,7 +4,8 @@ import java.util.List;
 import java.util.Map;
 
 public interface MessageService {
-	int insertMessage(MessageVO vo);
+	int insertMessage(MessageVO vo, int userNo);
+	
 	//내가 보낸 쪽지
 	List<Map<String, Object>> selectSentMessage(int userNo);
 	

--- a/src/main/java/com/it/workit/message/model/MessageService.java
+++ b/src/main/java/com/it/workit/message/model/MessageService.java
@@ -20,8 +20,5 @@ public interface MessageService {
 	//삭제플래그 업데이트 => 보낸 메세지 삭제 (개별/다중)
 	int updateMsgDelflag(int messageNo);
 	int updateMsgDelflagMulti(List<MessageVO> msgList);
-	
-	//삭제플래그 업데이트 => 받은 메세지 삭제
-	int updategetMsgDelflag(int messageNo);
 
 }

--- a/src/main/java/com/it/workit/message/model/MessageServiceImpl.java
+++ b/src/main/java/com/it/workit/message/model/MessageServiceImpl.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
+import com.it.workit.getmessage.model.GetMessageVO;
+
 @Service
 public class MessageServiceImpl implements MessageService{
 	
@@ -38,12 +40,13 @@ public class MessageServiceImpl implements MessageService{
 		return messageDao.selectByMessageNo(messageNo);
 	}
 	
+	//보낸 메세지 삭제 (플래그 업데이트) - 개별
 	@Override
 	public int updateMsgDelflag(int messageNo) {
 		return messageDao.updateMsgDelflag(messageNo);
 	}
 	
-	//보낸 메세지 삭제 (플래그 업데이트)
+	//보낸 메세지 삭제 (플래그 업데이트) - 다중
 	@Override
 	@Transactional
 	public int updateMsgDelflagMulti(List<MessageVO> msgList) {
@@ -61,12 +64,6 @@ public class MessageServiceImpl implements MessageService{
 			TransactionAspectSupport.currentTransactionStatus().setRollbackOnly();
 		}
 		return cnt;
-	}
-
-	//받은 메세지 삭제 (플래그 업데이트)
-	@Override
-	public int updategetMsgDelflag(int messageNo) {
-		return messageDao.updategetMsgDelflag(messageNo);
 	}
 
 }

--- a/src/main/java/com/it/workit/message/model/MessageServiceImpl.java
+++ b/src/main/java/com/it/workit/message/model/MessageServiceImpl.java
@@ -8,16 +8,32 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.interceptor.TransactionAspectSupport;
 
+import com.it.workit.getmessage.model.GetMessageDAO;
 import com.it.workit.getmessage.model.GetMessageVO;
+import com.it.workit.getposition.model.GetPositionsuggestVO;
+import com.it.workit.position.model.PositionsuggestVO;
 
 @Service
 public class MessageServiceImpl implements MessageService{
 	
 	@Autowired private MessageDAO messageDao;
+	@Autowired private GetMessageDAO getMessageDao;
 
 	@Override
-	public int insertMessage(MessageVO vo) {
-		return messageDao.insertMessage(vo);
+	@Transactional
+	public int insertMessage(MessageVO vo, int getUserNo) {
+		int cnt = messageDao.insertMessage(vo);
+		
+		//시퀀스 번호 얻기위해 조회
+		vo = messageDao.selectMsgJustNow(vo.getUserNo());
+		
+		//보내면 받는 사람도 insert
+		GetMessageVO gVo =  new GetMessageVO();
+		gVo.setUserNo(getUserNo);
+		gVo.setMessageNo(vo.getMessageNo());
+		cnt = getMessageDao.insertGetMessage(gVo);
+		
+		return cnt;
 	}
 
 	@Override

--- a/src/main/java/com/it/workit/prohibit/model/ProhibitJoinDAO.java
+++ b/src/main/java/com/it/workit/prohibit/model/ProhibitJoinDAO.java
@@ -9,7 +9,6 @@ public interface ProhibitJoinDAO {
 	int insertProhibit (ProhibitJoinVO vo);
 	int selectIfProhibited(int userIndivNo);
 	
-	int selectProhibitCount(CorpApplicantPagingVO vo);
 	public List<Map<String, Object>> selectProhibitedList(ProhibitJoinPagingVO vo);
 	int deleteFromProhibit(int prohibitjoinNo);
 	int selectProhibitTotal(int userCorpNo);

--- a/src/main/java/com/it/workit/prohibit/model/ProhibitJoinDAOMybatis.java
+++ b/src/main/java/com/it/workit/prohibit/model/ProhibitJoinDAOMybatis.java
@@ -26,11 +26,6 @@ public class ProhibitJoinDAOMybatis implements ProhibitJoinDAO{
 	public int selectIfProhibited(int userIndivNo) {
 		return sqlSession.selectOne(namespace+"selectIfProhibited", userIndivNo);
 	}
-	
-	@Override
-	public int selectProhibitCount(CorpApplicantPagingVO vo) {
-		return sqlSession.selectOne(namespace+"selectProhibitCount", vo);
-	}
 
 	@Override
 	public List<Map<String, Object>> selectProhibitedList(ProhibitJoinPagingVO vo) {

--- a/src/main/java/com/it/workit/prohibit/model/ProhibitJoinService.java
+++ b/src/main/java/com/it/workit/prohibit/model/ProhibitJoinService.java
@@ -9,7 +9,6 @@ public interface ProhibitJoinService {
 	int insertProhibit (ProhibitJoinVO vo);
 	int selectIfProhibited(int userIndivNo);
 	
-	int selectProhibitCount(CorpApplicantPagingVO vo);
 	public List<Map<String, Object>> selectProhibitedList(ProhibitJoinPagingVO vo);
 	int deleteFromProhibit(int userIndivNo);
 	int selectProhibitTotal(int userCorpNo);

--- a/src/main/java/com/it/workit/prohibit/model/ProhibitJoinServiceImpl.java
+++ b/src/main/java/com/it/workit/prohibit/model/ProhibitJoinServiceImpl.java
@@ -21,11 +21,6 @@ public class ProhibitJoinServiceImpl implements ProhibitJoinService {
 	public int selectIfProhibited(int userIndivNo) {
 		return prohibitDao.selectIfProhibited(userIndivNo);
 	}
-	
-	@Override
-	public int selectProhibitCount(CorpApplicantPagingVO vo) {
-		return prohibitDao.selectProhibitCount(vo);
-	}
 
 	@Override
 	public List<Map<String, Object>> selectProhibitedList(ProhibitJoinPagingVO vo) {

--- a/src/main/resources/config/mybatis/mapper/oracle/applicant.xml
+++ b/src/main/resources/config/mybatis/mapper/oracle/applicant.xml
@@ -187,19 +187,6 @@
 	   	</if>
 	</select>
 	
-	<!-- 입사제한자 수음 -->
-	<select id="selectProhibitCount" parameterType="CorpApplicantPagingVO" resultType="int">
-		select count(*) 
-		from APPLICANTLIST a join RECRUITANNOUNCE r
-		on a.RECRUITANNOUNCE_NO = r.RECRUITANNOUNCE_NO 
-		where r.RECRUITANNOUNCE_NO in (select RECRUITANNOUNCE_NO from APPLICANTLIST
-		    where RECRUITANNOUNCE_NO in (select RECRUITANNOUNCE_NO from RECRUITANNOUNCE where user_no=#{userNo}))
-		and a.USER_NO in (select USER_INDIV_NO from PROHIBITJOIN)
-   	    <if test="recruitannounceNo!=0">
-	   		and r.RECRUITANNOUNCE_NO=#{recruitannounceNo}
-	   	</if>
-	</select>
-	
 	<!-- 기업회원이 지원자 이력서 읽음 -->	
 	<update id="updateReadCount" parameterType="int">
 		update APPLICANTLIST

--- a/src/main/resources/config/mybatis/mapper/oracle/message.xml
+++ b/src/main/resources/config/mybatis/mapper/oracle/message.xml
@@ -19,6 +19,19 @@
 		values(#{getMessageNo}, #{userNo}, #{messageNo})
 	</insert>
 	
+	<!-- 회원이 방금 보낸 제안 조회 -->
+	<select id="selectMsgJustNow" parameterType="int" resultType="messageVo">
+		select A.*
+		from
+		(
+		    select * from message 
+		    where USER_NO=#{userNo}
+		    ORDER BY MESSAGE_REGDATE desc
+		)A
+		where rownum=1
+	</select>
+	
+	
 	<select id="selectSentMessage" parameterType="int" resultType="map">
 		select A.*
 		from

--- a/src/main/webapp/WEB-INF/views/admin/message/sendMessage.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/message/sendMessage.jsp
@@ -78,7 +78,7 @@
 	                            <div class="form-group">
 	                                <label for="corpName" class="col-form-label">받는 기업</label>
 	                                <input id="corpName" type="text" class="form-control" value="${corpName}" readonly>
-	                                <input id="userNo" type="hidden" class="form-control" value="${userNo}" name="getMessageNo">
+	                                <input id="userNo" type="hidden" class="form-control" value="${userNo}" name="getUserNo">
 	                                <label for="msgTitle" class="col-form-label">제목</label>
 	                                <input id="msgTitle" type="text" class="form-control" name="messageTitle" maxlength="30" style="margin-bottom: 10px;" value="${corpName}의 기업 등록이 반려 되었습니다." readonly >
                                     <label for="exampleFormControlTextarea1">반려 사유</label>

--- a/src/main/webapp/WEB-INF/views/admin/paidService/coupon/updateForm.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/paidService/coupon/updateForm.jsp
@@ -25,12 +25,43 @@
     <title>Work IT - 관리자 페이지</title>
     
 </head>
+
+<script src="<c:url value='/resources/admin/assets/vendor/jquery/jquery-3.3.1.min.js'/>"></script>
+<script type="text/javascript">
+	function cancle(){
+		window.close();
+	}
+	
+	function send(){
+		var params = $("#couponUpdateFrm").serialize();
+		$.ajax(
+		{
+			url :"<c:url value='/admin/paidService/coupon/update.do'/>",
+			type:"POST",
+			data : params,
+			async: false,
+			success : function(res)
+					{
+						if(res==1){
+							alert("쿠폰 정보가 수정되었습니다.");
+							opener.location.reload();
+							window.close();
+						}else{
+							alert("쿠폰 정보 수정에 실패했습니다.");
+							window.close();
+						}
+					}
+		});
+		event.preventDefault();
+	}
+</script>
+
 <body>
 
 	<div class="card">
 	    <h5 class="card-header">수정</h5>
 	    <div class="card-body">
-	        <form id="couponUpdateFrm" action="<c:url value='/admin/paidService/coupon/update.do'/>" method="post">
+	        <form id="couponUpdateFrm" method="post">
 	            <div class="form-group row">
 	                <label class="col-12 col-sm-3 col-form-label text-sm-right">쿠폰명</label>
 	                <div class="col-12 col-sm-8 col-lg-6">
@@ -60,7 +91,8 @@
 	            </div>
 	            <div class="form-group row text-right">
 	                <div class="col col-sm-10 col-lg-9 offset-sm-1 offset-lg-0">
-	                    <button type="submit" class="btn btn-space btn btn-primary">쿠폰 수정</button>
+	                    <button type="reset" class="btn btn-space btn btn-outline-primary" onclick="cancle()">취소</button>
+	                    <button type="submit" class="btn btn-space btn btn-primary" onclick="send()">쿠폰 수정</button>
 	                </div>
 	            </div>
 	        </form>

--- a/src/main/webapp/WEB-INF/views/company/HRManagment/position/positionSuggest.jsp
+++ b/src/main/webapp/WEB-INF/views/company/HRManagment/position/positionSuggest.jsp
@@ -17,6 +17,8 @@
 			if(len==0){
 			   alert('먼저 삭제할 제안을 선택하세요.');
 			   return false;
+			}else if(!confirm('해당 제안을 삭제하시겠습니까?')){
+				event.preventDefault();
 			}
 			
 			if($('#type').html()==''){

--- a/src/main/webapp/WEB-INF/views/message/messageBox.jsp
+++ b/src/main/webapp/WEB-INF/views/message/messageBox.jsp
@@ -13,13 +13,23 @@
 	$(function(){
 		$('#btImp').click(function(){
 			var len=$('.cart-table tbody tr td').find('input[type=checkbox]:checked').length;
-			            //여러개 이므로 배열 length사용 가능
 			if(len==0){
 			   alert('먼저 보관할 쪽지를 선택하세요.');
 			   return false;
 			}
-			
 			$('form[name=frmGetList]').prop('action', '<c:url value="/message/impMultiGetMsg.do"/>');
+			$('form[name=frmGetList]').submit();
+		});
+		
+		$('#btDel').click(function(){
+			var len=$('.cart-table tbody tr td').find('input[type=checkbox]:checked').length;
+			if(len==0){
+			   alert('먼저 삭제할 쪽지를 선택하세요.');
+			   return false;
+			}
+			
+			var type = $('#type').html();
+			$('form[name=frmGetList]').prop('action', '<c:url value="/message/deleteMultigetMsg.do?type="'+type+'/>');
 			$('form[name=frmGetList]').submit();
 			
 		});
@@ -32,6 +42,7 @@
 		<h2>받은쪽지함</h2>
 	</c:if>
 	<c:if test="${!empty param.type }">
+		<p id="type" style="display: none;">${param.type }</p>
 		<c:if test="${param.type == 'toMe'}">
 			<h2>나에게 쓴 쪽지함</h2>
 		</c:if>
@@ -83,7 +94,6 @@
 							<!-- 받은 쪽지함 --> 
 							<c:if test="${empty param.type}">
 								<a href="<c:url value="/message/countUpdate.do?getMessageNo=${map['MESSAGE_NO']}"/>">
-									<!-- 제목이 긴 경우 일부만 보여주기 -->							
 									<c:if test="${fn:length(map['MESSAGE_TITLE'])>=20}">
 										${fn:substring(map['MESSAGE_TITLE'], 0,20) } ...
 									</c:if>

--- a/src/main/webapp/WEB-INF/views/message/messageBox.jsp
+++ b/src/main/webapp/WEB-INF/views/message/messageBox.jsp
@@ -26,7 +26,10 @@
 			if(len==0){
 			   alert('먼저 삭제할 쪽지를 선택하세요.');
 			   return false;
+			}else if(!confirm('해당 쪽지를 삭제하시겠습니까?')){
+				event.preventDefault();
 			}
+
 			$('form[name=frmGetList]').prop('action', '<c:url value="/message/deleteMultigetMsg.do"/>');
 			$('form[name=frmGetList]').submit();
 		});

--- a/src/main/webapp/WEB-INF/views/message/messageBox.jsp
+++ b/src/main/webapp/WEB-INF/views/message/messageBox.jsp
@@ -27,11 +27,8 @@
 			   alert('먼저 삭제할 쪽지를 선택하세요.');
 			   return false;
 			}
-			
-			var type = $('#type').html();
-			$('form[name=frmGetList]').prop('action', '<c:url value="/message/deleteMultigetMsg.do?type="'+type+'/>');
+			$('form[name=frmGetList]').prop('action', '<c:url value="/message/deleteMultigetMsg.do"/>');
 			$('form[name=frmGetList]').submit();
-			
 		});
 	});
 </script>
@@ -42,7 +39,6 @@
 		<h2>받은쪽지함</h2>
 	</c:if>
 	<c:if test="${!empty param.type }">
-		<p id="type" style="display: none;">${param.type }</p>
 		<c:if test="${param.type == 'toMe'}">
 			<h2>나에게 쓴 쪽지함</h2>
 		</c:if>
@@ -55,7 +51,8 @@
 
 <!-- 받은쪽지함 부분 시작-->
 <form name="frmGetList" method="post" action="<c:url value='/message/messageBox.do'/>">
-	
+<input type="hidden" name="type" value="${param.type }">
+
 <div class="cart-table">
 	<table>
 		<colgroup>
@@ -93,7 +90,7 @@
 						<td style="text-align: left;">
 							<!-- 받은 쪽지함 --> 
 							<c:if test="${empty param.type}">
-								<a href="<c:url value="/message/countUpdate.do?getMessageNo=${map['MESSAGE_NO']}"/>">
+								<a href="<c:url value='/message/countUpdate.do?getMessageNo=${map["MESSAGE_NO"]}'/>">
 									<c:if test="${fn:length(map['MESSAGE_TITLE'])>=20}">
 										${fn:substring(map['MESSAGE_TITLE'], 0,20) } ...
 									</c:if>
@@ -105,7 +102,7 @@
 							<c:if test="${!empty param.type}">
 								<!-- 보관함에 저장된 경우 -->
 								<c:if test="${param.type == 'important'}">
-									<a href="<c:url value="/message/countUpdate.do?getMessageNo=${map['MESSAGE_NO']}"/>">
+									<a href="<c:url value='/message/countUpdate.do?getMessageNo=${map["MESSAGE_NO"]}'/>">
 										<!-- 제목이 긴 경우 일부만 보여주기 -->							
 										<c:if test="${fn:length(map['MESSAGE_TITLE'])>=30}">
 											${fn:substring(map['MESSAGE_TITLE'], 0,30) } ...
@@ -117,7 +114,7 @@
 								</c:if>
 								<!-- 나에게 보낸 편지함 -->
 								<c:if test="${param.type == 'toMe'}">
-									<a href="<c:url value="/message/messageDetail.do?type=toMe&getMessageNo=${map['MESSAGE_NO']}"/>">
+									<a href="<c:url value='/message/messageDetail.do?type=toMe&getMessageNo=${map["MESSAGE_NO"]}'/>">
 										<!-- 제목이 긴 경우 일부만 보여주기 -->							
 										<c:if test="${fn:length(map['MESSAGE_TITLE'])>=30}">
 											${fn:substring(map['MESSAGE_TITLE'], 0,30) } ...

--- a/src/main/webapp/WEB-INF/views/message/messageBoxSend.jsp
+++ b/src/main/webapp/WEB-INF/views/message/messageBoxSend.jsp
@@ -17,7 +17,10 @@
 			if(len==0){
 			   alert('먼저 삭제할 쪽지를 선택하세요.');
 			   return false;
+			}else if(!confirm('해당 쪽지를 삭제하시겠습니까?')){
+				event.preventDefault();
 			}
+			
 			$('form[name=frmList]').prop('action', '<c:url value="/message/deleteMultiMsg.do"/>');
 			$('form[name=frmList]').submit();
 			

--- a/src/main/webapp/WEB-INF/views/message/messageBoxSend.jsp
+++ b/src/main/webapp/WEB-INF/views/message/messageBoxSend.jsp
@@ -12,25 +12,12 @@
 
 <script type="text/javascript">
 	$(function(){
-		$('.cart-table table tbody tr td .ti-close').click(function(){
-			if($('#openFlag').html()=='미열람'){
-				if(!confirm('해당 쪽지 전송을 취소하시겠습니까?\n쪽지 전송을 취소할 경우, 해당 쪽지는 자동삭제됩니다.')){
-					event.preventDefault();
-				}
-			}else if($('#openFlag').html()=='열람'){
-				alert('상대방이 열람한 쪽지는 전송을 취소할 수 없습니다.');
-				event.preventDefault();
-			}
-		});
-		
 		$('#btDel').click(function(){
 			var len=$('.cart-table tbody tr td').find('input[type=checkbox]:checked').length;
-
 			if(len==0){
 			   alert('먼저 삭제할 쪽지를 선택하세요.');
 			   return false;
 			}
-			            
 			$('form[name=frmList]').prop('action', '<c:url value="/message/deleteMultiMsg.do"/>');
 			$('form[name=frmList]').submit();
 			
@@ -109,13 +96,6 @@
 						<c:if test="${map['GETMESSAGE_READFLAG']==1}">
 							<td id="openFlag">열람</td>
 						</c:if>
-<%-- 						
-						<td>
-							<a href="<c:url value='/message/deleteMsg.do?messageNo=${map["MESSAGE_NO"]}'/>">
-								<i class="ti-close" style="cursor: pointer;"></i>
-							</a>
-						</td>
-						 --%>
 					</tr>
 					<c:set var="k" value="${k+1}"/>
 				</c:forEach>


### PR DESCRIPTION
- 기존 쪽지함에서 다중삭제처리 일부만 구현된 부분 수정 보완 => 모든 분류 내 쪽지함에서 동작 가능
- 쪽지함 트랜잭션처리로 수정
- 위의 변경에 따른 관리자 기업반려 쪽지 송신 컨트롤러 로직 수정
- 관리자 쿠폰관리 수정 ajax로 변경 및 자식창 닫음 처리 동시에 부모창 새로고침 구현
- 입사지원제한자 수 맞지 않았던 오류 수정 보완